### PR TITLE
add new version for generate ATS version of each CV

### DIFF
--- a/.babelignore
+++ b/.babelignore
@@ -1,0 +1,4 @@
+apps/web/scripts/**
+apps/*/scripts/**
+**/scripts/**/*.js
+

--- a/apps/native/src/templates/Default.tsx
+++ b/apps/native/src/templates/Default.tsx
@@ -5,7 +5,7 @@ import Footer from "app/components/Footer";
 import { TemplateProps } from "types/components";
 import { useSettings } from "app/hooks/useSettings";
 
-const DefaultTemplate: React.FC<TemplateProps> = ({ children }) => {
+const DefaultTemplate: React.FC<TemplateProps> = ({ children, isATS = false }) => {
   const settings = useSettings();
   return (
     <SafeAreaView>
@@ -13,7 +13,7 @@ const DefaultTemplate: React.FC<TemplateProps> = ({ children }) => {
         contentInsetAdjustmentBehavior="automatic"
         className="w-full h-full  pt-8"
         style={{
-          backgroundColor: settings?.mainBackground?.hex,
+          backgroundColor: isATS ? "#313638" : settings?.mainBackground?.hex,
         }}
       >
         <Header />

--- a/apps/web/.eslintignore
+++ b/apps/web/.eslintignore
@@ -1,0 +1,3 @@
+scripts/**
+scripts/*.js
+

--- a/apps/web/src/app/api/pdf/[slug]/route.ts
+++ b/apps/web/src/app/api/pdf/[slug]/route.ts
@@ -31,11 +31,13 @@ export async function GET(request: NextRequest) {
     // Fetch all blobs
     const { blobs } = await list({ prefix: `${STORAGE_NAME}` });
     // Filter blobs to include only those matching the specific role/slug
-    const filteredBlobs = blobs.filter(
-      (blob) =>
-        blob.pathname.includes(`/${role}-`) ||
-        blob.pathname.includes(`/${role}.`),
-    );
+    // Be precise: match exact filename to avoid matching both regular and ATS versions
+    const filteredBlobs = blobs.filter((blob) => {
+      const pathname = blob.pathname;
+      // Match exact filename ending: must end with /{role}.pdf
+      // This ensures "george.barbu" doesn't match "george.barbu-ats.pdf"
+      return pathname.endsWith(`/${role}.pdf`);
+    });
 
     if (!filteredBlobs || filteredBlobs.length === 0) {
       console.warn(`No PDFs found for role: ${role}`);

--- a/apps/web/src/templates/Classic.tsx
+++ b/apps/web/src/templates/Classic.tsx
@@ -4,14 +4,14 @@ import Footer from "app/components/Footer";
 import { TemplateProps } from "types/components";
 import { useSettings } from "app/hooks/useSettings";
 
-export default function ClassicTemplate({ children }: TemplateProps) {
+export default function ClassicTemplate({ children, isATS = false }: TemplateProps) {
   const settings = useSettings();
 
   return (
     <main
       className="w-full first-letter:min-h-screen classicTemplate"
       style={{
-        backgroundColor: settings?.mainBackground?.hex,
+        backgroundColor: isATS ? "#313638" : settings?.mainBackground?.hex,
         color: settings?.mainTextColor?.hex,
       }}
     >

--- a/apps/web/src/templates/Default.tsx
+++ b/apps/web/src/templates/Default.tsx
@@ -4,14 +4,14 @@ import Footer from "app/components/Footer";
 import { TemplateProps } from "types/components";
 import { useSettings } from "app/hooks/useSettings";
 
-export default function DefaultTemplate({ children }: TemplateProps) {
+export default function DefaultTemplate({ children, isATS = false }: TemplateProps) {
   const settings = useSettings();
 
   return (
     <main
       className="w-full first-letter:min-h-screen defaultTemplate"
       style={{
-        backgroundColor: settings?.mainBackground?.hex,
+        backgroundColor: isATS ? "#313638" : settings?.mainBackground?.hex,
         color: settings?.mainTextColor?.hex,
       }}
     >

--- a/apps/web/src/templates/Modern.tsx
+++ b/apps/web/src/templates/Modern.tsx
@@ -4,14 +4,14 @@ import Footer from "app/components/Footer";
 import { TemplateProps } from "types/components";
 import { useSettings } from "app/hooks/useSettings";
 
-export default function ModernTemplate({ children }: TemplateProps) {
+export default function ModernTemplate({ children, isATS = false }: TemplateProps) {
   const settings = useSettings();
 
   return (
     <main
       className="w-full first-letter:min-h-screen modernTemplate"
       style={{
-        backgroundColor: settings?.mainBackground?.hex,
+        backgroundColor: isATS ? "#313638" : settings?.mainBackground?.hex,
         color: settings?.mainTextColor?.hex,
       }}
     >

--- a/babel.config.js
+++ b/babel.config.js
@@ -3,5 +3,9 @@ module.exports = function (api) {
   return {
     presets: ["babel-preset-expo"],
     plugins: ["nativewind/babel"],
+    ignore: [
+      "**/scripts/**/*.js",
+      "apps/web/scripts/**",
+    ],
   };
 };

--- a/packages/app/components/Footer.tsx
+++ b/packages/app/components/Footer.tsx
@@ -4,23 +4,33 @@ import { View as ViewWEB } from "ui/view";
 import { useResumeData } from "app/context/ResumeContext";
 import { useSettings } from "app/hooks/useSettings";
 
-const Footer: React.FC = ({}) => {
+const Footer: React.FC = () => {
   const settings = useSettings();
   const resumeData = useResumeData();
   const social = Array.isArray(resumeData?.footer)
     ? resumeData?.footer[0]?.social || []
     : [];
+  
+  // Detect if we're on an ATS page
+  let isATS = false;
+  if (typeof window !== "undefined") {
+    const pathname = window.location.pathname;
+    isATS = pathname === "/ats" || (pathname.length > 4 && pathname.endsWith("-ats"));
+  }
 
   return (
     <ViewWEB
       data-exclude="true"
       className="max-w-screen-pdf py-6 mb-5 mx-auto items-center justify-between w-full md:flex lg:flex-row  print:invisible"
+      style={{
+        backgroundColor: isATS ? "#313638" : "transparent",
+      }}
     >
       <View className="flex-row items-center tracking-wide mb-5 md:mb-0 justify-center ml-2 sm:ml-0">
         <Text
           className="text-sm mr-1 "
           style={{
-            color: settings?.footerTextColor?.hex,
+            color: isATS ? "#525659" : settings?.footerTextColor?.hex,
           }}
         >
           © {new Date().getFullYear()} | Developed with
@@ -36,7 +46,7 @@ const Footer: React.FC = ({}) => {
         <Text
           className=" text-sm mr-1"
           style={{
-            color: settings?.footerTextColor?.hex,
+            color: isATS ? "#525659" : settings?.footerTextColor?.hex,
           }}
         >
           by
@@ -62,7 +72,7 @@ const Footer: React.FC = ({}) => {
             <Text className="ml-4 last:ml-o">
               <Icon
                 name={item.service}
-                color={settings?.footerIconsColor?.hex}
+                color={isATS ? "#525659" : settings?.footerIconsColor?.hex}
                 className="!text-[28px]"
               />
             </Text>

--- a/packages/app/screens/HomeATS.tsx
+++ b/packages/app/screens/HomeATS.tsx
@@ -1,0 +1,377 @@
+import React from "react";
+import { View, Text, Linking, TouchableOpacity } from "react-native";
+import { useResumeData } from "app/context/ResumeContext";
+
+/**
+ * ATS-optimized resume layout
+ * Two-column design matching modern resume templates, optimized for ATS parsing
+ */
+export const HomeATS: React.FC = () => {
+  const resumeData = useResumeData();
+  const header = resumeData?.header?.[0];
+  const sidebar = resumeData?.sidebar?.[0];
+  const content = resumeData?.content?.[0];
+
+  // Get all skills and separate technical from soft skills if possible
+  const allSkills = sidebar?.skillsSections || [];
+  const technicalSkills = allSkills.find(s => s.label?.toLowerCase().includes("technical") || (!s.label?.toLowerCase().includes("soft") && s.label));
+  const softSkills = allSkills.find(s => s.label?.toLowerCase().includes("soft"));
+
+  // Format date to "YYYY" format (e.g., "2022")
+  const formatDate = (dateString?: string) => {
+    if (!dateString) return "";
+    const date = new Date(dateString);
+    if (isNaN(date.getTime())) return dateString;
+    const year = date.getFullYear();
+    return `${year}`;
+  };
+
+  // Format date range for experience
+  const formatDateRange = (startDate?: string, endDate?: string, presentDate?: boolean) => {
+    const start = formatDate(startDate);
+    const end = presentDate ? "Present" : formatDate(endDate);
+    if (!start && !end) return "";
+    if (!start) return end;
+    if (!end) return start;
+    return `${start} – ${end}`;
+  };
+
+  // Get URL from contact item value
+  const getUrl = (value?: string, service?: string) => {
+    if (!value) return "";
+    if (value.startsWith("http://") || value.startsWith("https://")) return value;
+    if (service === "email") return `mailto:${value}`;
+    if (service === "phone" || service === "homephone") return `tel:${value}`;
+    if (service === "linkedin") return `https://linkedin.com/in/${value.replace(/^.*\//, "")}`;
+    if (service === "github") return `https://github.com/${value.replace(/^.*\//, "")}`;
+    return value;
+  };
+
+  return (
+    <View className="printColor w-full print:bg-[#313638] bg-[#313638] font-sans block [writing-mode:horizontal-tb] [text-orientation:mixed]">
+      <View className="printColor print:bg-[#313638] max-w-screen-pdf w-full mx-auto box-border bg-[#313638] print:py-10 print:px-8 print:pt-10 block">
+        {/* Header Section */}
+        {header?.fullname && (
+          <View className="mb-8 pb-5 pt-5 border-b border-b-[rgba(255,255,255,0.15)]">
+            <Text className="text-4xl font-bold text-white mb-2 tracking-[-0.5px] block whitespace-normal">
+              {header.fullname.toUpperCase()}
+            </Text>
+            {header.role && (
+              <Text className="text-[15px] text-[#e5e5e5] font-normal block whitespace-normal">
+                {header.role}
+              </Text>
+            )}
+          </View>
+        )}
+
+        {/* Two Column Layout */}
+        <View className="flex flex-row gap-10 [writing-mode:horizontal-tb] [text-orientation:mixed]">
+          {/* Left Column - Main Content */}
+          <View className="flex-1 min-w-0">
+            {/* Summary Section */}
+            {sidebar?.summarySection?.summary && (
+              <View className="mb-3">
+                <Text className="text-[15px] font-bold mb-2 uppercase tracking-[1px] text-[#c084fc] block whitespace-normal">
+                  {sidebar.summarySection.label || "SUMMARY"}
+                </Text>
+                <Text className="text-[13px] text-white leading-[19px] text-justify block whitespace-normal">
+                  {sidebar.summarySection.summary}
+                </Text>
+              </View>
+            )}
+
+            {/* Work Experience Section */}
+            {content?.experienceSection?.items && content.experienceSection.items.length > 0 && (
+              <View className="mb-7">
+                <Text className="text-[15px] font-bold mb-2 mt-8 uppercase tracking-[1px] text-[#c084fc] block whitespace-normal">
+                  {content.experienceSection.label || "PROFESSIONAL EXPERIENCE"}
+                </Text>
+                {content.experienceSection.items.map((item, idx) => {
+                  const dateRange = formatDateRange(
+                    item.experienceDates?.startDate,
+                    item.experienceDates?.endDate,
+                    item.experienceDates?.presentDate
+                  );
+
+                  return (
+                    <View key={idx} className="mb-6">
+                      {/* Job Title and Date */}
+                      <View className="flex flex-row justify-between items-start mb-1 [writing-mode:horizontal-tb] [text-orientation:mixed]">
+                        <Text className="text-sm font-bold text-white flex-1 block whitespace-normal break-normal">
+                          {item.role || ""}
+                        </Text>
+                        {dateRange && (
+                          <Text className="text-[11px] text-[#a0a0a0] ml-4 whitespace-nowrap inline-block">
+                            {dateRange}
+                          </Text>
+                        )}
+                      </View>
+                      {/* Company */}
+                      <Text className="text-[13px] text-white font-semibold mb-2 block whitespace-normal">
+                        {item.company || ""}
+                      </Text>
+                      {/* Bullet Points (Duties) */}
+                      {item.duties && item.duties.length > 0 && (
+                        <View className="mt-1.5">
+                          {item.duties.map((duty, dIdx) => (
+                            <View key={dIdx} className="flex flex-row mb-1.5 [writing-mode:horizontal-tb]">
+                              <Text className="text-xs text-white mr-2 inline-block">•</Text>
+                              <Text className="text-xs text-white leading-[19px] flex-1 text-justify block whitespace-normal">
+                                {duty}
+                              </Text>
+                            </View>
+                          ))}
+                        </View>
+                      )}
+                    </View>
+                  );
+                })}
+              </View>
+            )}
+
+            {/* Early Career Section */}
+            {content?.earlyCareerExperienceSection?.items &&
+              content.earlyCareerExperienceSection.items.length > 0 && (
+                <View className="mb-7">
+                  <Text className="text-[15px] font-bold mb-3.5 uppercase tracking-[1px] text-[#c084fc] block whitespace-normal">
+                    {content.earlyCareerExperienceSection.label || "EARLY CAREER EXPERIENCE"}
+                  </Text>
+                  {content.earlyCareerExperienceSection.items.map((item, idx) => {
+                    const dateRange = formatDateRange(
+                      item.experienceDates?.startDate,
+                      item.experienceDates?.endDate,
+                      item.experienceDates?.presentDate
+                    );
+
+                    return (
+                        <View key={idx} className="mb-8">
+                          <View className="flex flex-row justify-between items-start mb-1 [writing-mode:horizontal-tb]">
+                            <Text className="text-sm font-bold text-white flex-1 block whitespace-normal">
+                              {item.role || ""}
+                            </Text>
+                          {dateRange && (
+                            <Text className="text-[11px] text-[#a0a0a0] ml-4 whitespace-nowrap inline-block">
+                              {dateRange}
+                            </Text>
+                          )}
+                        </View>
+                        <Text className="text-[13px] text-white font-semibold mb-2 block whitespace-normal">
+                          {item.company || ""}
+                        </Text>
+                        {item.duties && item.duties.length > 0 && (
+                          <View className="mt-1.5">
+                            {item.duties.map((duty, dIdx) => (
+                              <View key={dIdx} className="flex flex-row mb-1.5 [writing-mode:horizontal-tb]">
+                                <Text className="text-xs text-white mr-2 inline-block">•</Text>
+                                <Text className="text-xs text-white leading-[19px] flex-1 text-justify block whitespace-normal">
+                                  {duty}
+                                </Text>
+                              </View>
+                            ))}
+                          </View>
+                        )}
+                      </View>
+                    );
+                  })}
+                </View>
+              )}
+
+            {/* NGO Experience Section */}
+            {content?.ngoExperienceSection?.items &&
+              content.ngoExperienceSection.items.length > 0 && (
+                <View className="mb-7">
+                  <Text className="text-[15px] font-bold mb-3.5 uppercase tracking-[1px] text-[#c084fc] block whitespace-normal">
+                    {content.ngoExperienceSection.label || "NGO EXPERIENCE"}
+                  </Text>
+                  {content.ngoExperienceSection.items.map((item, idx) => {
+                    const dateRange = formatDateRange(
+                      item.experienceDates?.startDate,
+                      item.experienceDates?.endDate,
+                      item.experienceDates?.presentDate
+                    );
+
+                    return (
+                      <View key={idx} className="mb-8">
+                        <View className="flex flex-row justify-between items-start mb-1 [writing-mode:horizontal-tb]">
+                          <Text className="text-sm font-bold text-white flex-1 block whitespace-normal">
+                            {item.role || ""}
+                          </Text>
+                          {dateRange && (
+                            <Text className="text-[11px] text-[#a0a0a0] ml-4 whitespace-nowrap inline-block">
+                              {dateRange}
+                            </Text>
+                          )}
+                        </View>
+                        <Text className="text-[13px] text-white font-semibold mb-2 block whitespace-normal">
+                          {item.company || ""}
+                        </Text>
+                        {item.duties && item.duties.length > 0 && (
+                          <View className="mt-1.5">
+                            {item.duties.map((duty, dIdx) => (
+                              <View key={dIdx} className="flex flex-row mb-1.5 [writing-mode:horizontal-tb]">
+                                <Text className="text-xs text-white mr-2 inline-block">•</Text>
+                                <Text className="text-xs text-white leading-[19px] flex-1 text-justify block whitespace-normal">
+                                  {duty}
+                                </Text>
+                              </View>
+                            ))}
+                          </View>
+                        )}
+                      </View>
+                    );
+                  })}
+                </View>
+              )}
+          </View>
+
+          {/* Right Column - Sidebar Content */}
+          <View className="w-[290px] shrink-0 block [writing-mode:horizontal-tb]">
+            {/* Contact Details */}
+            {sidebar?.contactSection?.items && sidebar.contactSection.items.length > 0 && (
+              <View className="mb-7">
+                  <Text className="text-[15px] font-bold mb-2 uppercase tracking-[1px] text-[#c084fc] block whitespace-normal">
+                    {sidebar.contactSection.label || "CONTACT DETAILS"}
+                  </Text>
+                <View>
+                  {sidebar.contactSection.items.map((item, idx) => {
+                    // Only show labels if showLabel is true
+                    const getLabel = () => {
+                      if (!item.showLabel) return "";
+                      
+                      // Use custom label first if it exists
+                      if (item.label) return `${item.label}: `;
+                      
+                      // Fall back to service-based labels
+                      if (item.service === "phone" || item.service === "homephone") return "Phone: ";
+                      if (item.service === "email") return "Email: ";
+                      if (item.service === "location") return "Location: ";
+                      if (item.service === "website") return "Website: ";
+                      if (item.service === "linkedin") return "LinkedIn: ";
+                      if (item.service === "github") return "GitHub: ";
+                      return "";
+                    };
+
+                    const label = getLabel();
+                    if (!item.value) return null;
+
+                    const url = getUrl(item.value, item.service);
+                    const isLink = item.service === "email" || item.service === "phone" || item.service === "homephone" || item.service === "linkedin" || item.service === "github" || item.service === "website";
+
+                    const content = (
+                      <Text className="text-[11.5px] leading-5 mb-2 block whitespace-normal">
+                        <Text className="font-semibold text-white inline">{label}</Text>
+                        <Text className={`${isLink ? "text-blue-400 underline" : "text-white"} inline whitespace-normal`}>
+                          {item.value}
+                        </Text>
+                      </Text>
+                    );
+
+                    if (isLink && url) {
+                      return (
+                        <TouchableOpacity 
+                          key={idx}
+                          onPress={() => Linking.openURL(url)}
+                        >
+                          {content}
+                        </TouchableOpacity>
+                      );
+                    }
+
+                    return (
+                      <View key={idx}>
+                        {content}
+                      </View>
+                    );
+                  })}
+                </View>
+              </View>
+            )}
+
+            {/* Skills Section */}
+            {technicalSkills && technicalSkills.items && technicalSkills.items.length > 0 && (
+              <View className="mb-7">
+                <Text className="text-[15px] font-bold mb-3.5 uppercase tracking-[1px] text-[#c084fc] block whitespace-normal">
+                  SKILLS
+                </Text>
+                <View>
+                  {technicalSkills.items.map((item, idx) => (
+                    <View key={idx} className="flex flex-row mb-1.5 [writing-mode:horizontal-tb]">
+                      <Text className="text-[11.5px] text-white mr-2 inline-block">•</Text>
+                      <Text className="text-[11.5px] text-white leading-[19px] flex-1 block whitespace-normal">
+                        {item.title || item.name}
+                      </Text>
+                    </View>
+                  ))}
+                </View>
+              </View>
+            )}
+
+            {/* Soft Skills Section */}
+            {softSkills && softSkills.items && softSkills.items.length > 0 && (
+              <View className="mb-7">
+                <Text className="text-[15px] font-bold mb-3.5 uppercase tracking-[1px] text-[#c084fc] block whitespace-normal">
+                  SOFT SKILLS
+                </Text>
+                <View>
+                  {softSkills.items.map((item, idx) => (
+                    <View key={idx} className="flex flex-row mb-1.5 [writing-mode:horizontal-tb]">
+                      <Text className="text-[11.5px] text-white mr-2 inline-block">•</Text>
+                      <Text className="text-[11.5px] text-white leading-[19px] flex-1 block whitespace-normal">
+                        {item.title || item.name}
+                      </Text>
+                    </View>
+                  ))}
+                </View>
+              </View>
+            )}
+
+            {/* Certifications Section */}
+            {content?.educationSection?.items &&
+              content.educationSection.items.some(item => item.certifications && item.certifications.length > 0) && (
+                <View className="mb-7">
+                  <Text className="text-[15px] font-bold mb-3.5 uppercase tracking-[1px] text-[#c084fc] block whitespace-normal">
+                    CERTIFICATIONS
+                  </Text>
+                  <View>
+                    {content.educationSection.items.map((item, idx) =>
+                      item.certifications?.map((cert, cIdx) => (
+                        <View key={`${idx}-${cIdx}`} className="flex flex-row mb-1.5 [writing-mode:horizontal-tb]">
+                            <Text className="text-[11.5px] text-white mr-2 inline-block">•</Text>
+                            <Text className="text-[11.5px] text-white leading-[19px] flex-1 block whitespace-normal">
+                            {cert}
+                          </Text>
+                        </View>
+                      ))
+                    )}
+                  </View>
+                </View>
+              )}
+
+            {/* Education Section */}
+            {content?.educationSection?.items &&
+              content.educationSection.items.length > 0 && (
+                <View className="mb-7">
+                  <Text className="text-[15px] font-bold mb-3.5 uppercase tracking-[1px] text-[#c084fc] block whitespace-normal">
+                    {content.educationSection.label || "EDUCATION"}
+                  </Text>
+                  {content.educationSection.items.map((item, idx) => (
+                    <View key={idx} className="mb-3.5">
+                      <Text className="text-[12.5px] font-bold text-white mb-1.5 leading-[18px] block whitespace-normal">
+                        {item.degree || ""}
+                        {item.type && ` in ${item.type}`}
+                      </Text>
+                      <Text className="text-[11.5px] text-[#e5e5e5] leading-[18px] block whitespace-normal">
+                        {item.institution || ""}
+                      </Text>
+                    </View>
+                  ))}
+                </View>
+              )}
+          </View>
+        </View>
+      </View>
+    </View>
+  );
+};
+
+export default HomeATS;

--- a/packages/types/src/components/templates.ts
+++ b/packages/types/src/components/templates.ts
@@ -2,4 +2,5 @@ import { ReactNode } from "react";
 
 export interface TemplateProps {
   children?: ReactNode;
+  isATS?: boolean;
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduce ATS-optimized resume routes/UI and generate/upload separate ATS PDFs alongside regular ones.
> 
> - **Routes/UI**:
>   - Add ATS variant routing: `'/ats'` and `'/[slug]-ats'`; derive `baseSlug` for data fetch.
>   - New `HomeATS` screen with two-column ATS-friendly layout.
>   - Pass `isATS` to templates (`web` and `native`) and adjust background/styling.
>   - Update `Header`/`Footer` to detect ATS via pathname, tweak colors, and use ATS-aware download/print actions.
> - **PDF Generation**:
>   - Update `generatePDF.js` and `blobPDF.js` to produce both standard and ATS PDFs per route.
>   - ATS PDFs use simplified rendering (no header/footer/background tweaks), different URL routing, and `-ats.pdf` filenames; upload to Vercel Blob.
>   - Add Puppeteer launch arg tweaks and timeouts.
> - **API**:
>   - Refine `GET /api/pdf/[slug]` to match exact filenames (`/{role}.pdf`) to avoid mixing regular/ATS files.
> - **Utilities/Types**:
>   - Extend Web actions to accept `isATS`, build proper API URLs, filenames, and printing.
>   - Add `isATS` to `TemplateProps`.
> - **Config**:
>   - Ignore script files in Babel and ESLint.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6862a643cb4101941f68737da4ba813d2b7f8f1b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced ATS (Applicant Tracking System) mode for viewing and downloading resumes.
  * Added ATS-optimized resume display with customized layout and dark theme styling.
  * PDFs now generated in ATS-compatible format with alternate styling.

* **Chores**
  * Updated build configuration to exclude script files from processing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->